### PR TITLE
Add CipherAhead - PQC cryptographic risk scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Whether you’re a **developer**, **researcher**, or **security architect**, thi
 - [PKI Consortium](https://pkic.org/)
 
 ## Software, Tools, Libraries
+ - [CipherAhead](https://cipherahead.com)
  - [OpenSSL](https://openssl-library.org/)
  - [Open Quantum Safe](https://openquantumsafe.org/)
  - [PQClean](https://github.com/PQClean/PQClean/)


### PR DESCRIPTION
CipherAhead is a cryptographic risk scanner that helps teams inventory vulnerable cryptography before the post-quantum transition. It scans GitHub repositories, local files, code snippets and live web applications, mapping findings to NIST PQC, CNSA 2.0 and BSI TR-02102 with file and line-level evidence.